### PR TITLE
Add Put api to replace tasks from database

### DIFF
--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -128,6 +128,11 @@ export class TasksController {
 >>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
 =======
 
+  @Delete('completed')
+  async removeCompleted(): Promise<void> {
+    await this.tasksService.removeCompleted();
+  }
+
   @Delete(':id')
   async deleteTask(@Param('id') id: string) {
     return await this.tasksService.deleteTask(+id);
@@ -140,10 +145,13 @@ export class TasksController {
   async findOne(@Param('id') id: string): Promise<Task> {
     return this.tasksService.findOne(+id);
   }
+<<<<<<< HEAD
 
   @Delete('completed')
   async removeCompleted(): Promise<void> {
     await this.tasksService.removeCompleted();
   }
 >>>>>>> c30c7e8 (feat(FTDAS): Add Get /todos/:id API to fetch one task)
+=======
+>>>>>>> a125ba2 (chore(FTDA): Fix delete completed task api issue)
 }

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -117,6 +117,11 @@ export class TasksController {
 >>>>>>> dc64799 (feat(FTDAS): Create POST /todos api to create task)
 =======
 
+  @Put('sync')
+  async syncTasks(@Body() tasks: Task[]): Promise<void> {
+    await this.tasksService.syncTasks(tasks);
+  }
+
   @Put(':id')
   async updateTask(
     @Param('id') id: string,

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -1,4 +1,5 @@
 <<<<<<< HEAD
+<<<<<<< HEAD
 import {
   Body,
   Controller,
@@ -18,6 +19,13 @@ import { Controller, Get } from '@nestjs/common';
 import { TasksService } from './tasks.service';
 import { Task } from 'src/common/entities/task.entity';
 >>>>>>> 66b362b (feat(FTDAS): Get api for all todos)
+=======
+import { Body, Controller, Get, Post } from '@nestjs/common';
+
+import { TasksService } from './tasks.service';
+import { Task } from 'src/common/entities/task.entity';
+import { CreateTaskDto } from './tasks.dto';
+>>>>>>> dc64799 (feat(FTDAS): Create POST /todos api to create task)
 
 @Controller('todos')
 export class TasksController {
@@ -27,6 +35,7 @@ export class TasksController {
   async findAll(): Promise<Task[]> {
     return this.tasksService.findAll();
   }
+<<<<<<< HEAD
 <<<<<<< HEAD
 
   @Post()
@@ -73,4 +82,11 @@ export class TasksController {
   }
 =======
 >>>>>>> 66b362b (feat(FTDAS): Get api for all todos)
+=======
+
+  @Post()
+  async createTask(@Body() createTaskDto: CreateTaskDto): Promise<Task> {
+    return await this.tasksService.createTask(createTaskDto);
+  }
+>>>>>>> dc64799 (feat(FTDAS): Create POST /todos api to create task)
 }

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -132,5 +132,13 @@ export class TasksController {
   async deleteTask(@Param('id') id: string) {
     return await this.tasksService.deleteTask(+id);
   }
+<<<<<<< HEAD
 >>>>>>> 31ac275 (feat(FTDAS): Add Delete /todos/:id api and delete functionality)
+=======
+
+  @Get(':id')
+  async findOneTask(@Param('id') id: string): Promise<Task> {
+    return this.tasksService.findOneTask(+id);
+  }
+>>>>>>> c30c7e8 (feat(FTDAS): Add Get /todos/:id API to fetch one task)
 }

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -1,6 +1,7 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 import {
   Body,
   Controller,
@@ -37,6 +38,13 @@ import { Task } from 'src/common/entities/task.entity';
 
 import { CreateTaskDto } from './tasks.dto';
 >>>>>>> dc64799 (feat(FTDAS): Create POST /todos api to create task)
+=======
+import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common';
+
+import { TasksService } from './tasks.service';
+import { Task } from 'src/common/entities/task.entity';
+import { CreateTaskDto, UpdateTaskDto } from './tasks.dto';
+>>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
 
 @Controller('todos')
 export class TasksController {
@@ -99,5 +107,16 @@ export class TasksController {
   async createTask(@Body() createTaskDto: CreateTaskDto): Promise<Task> {
     return await this.tasksService.createTask(createTaskDto);
   }
+<<<<<<< HEAD
 >>>>>>> dc64799 (feat(FTDAS): Create POST /todos api to create task)
+=======
+
+  @Put(':id')
+  async updateTask(
+    @Param('id') id: string,
+    @Body() updateTaskDto: UpdateTaskDto,
+  ): Promise<Task> {
+    return this.tasksService.updateTask(+id, updateTaskDto);
+  }
+>>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
 }

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -137,8 +137,13 @@ export class TasksController {
 =======
 
   @Get(':id')
-  async findOneTask(@Param('id') id: string): Promise<Task> {
-    return this.tasksService.findOneTask(+id);
+  async findOne(@Param('id') id: string): Promise<Task> {
+    return this.tasksService.findOne(+id);
+  }
+
+  @Delete('completed')
+  async removeCompleted(): Promise<void> {
+    await this.tasksService.removeCompleted();
   }
 >>>>>>> c30c7e8 (feat(FTDAS): Add Get /todos/:id API to fetch one task)
 }

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -1,5 +1,6 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 import {
   Body,
   Controller,
@@ -22,8 +23,18 @@ import { Task } from 'src/common/entities/task.entity';
 =======
 import { Body, Controller, Get, Post } from '@nestjs/common';
 
+=======
+import {
+  Body,
+  Controller,
+  Get,
+  InternalServerErrorException,
+  Post,
+} from '@nestjs/common';
+>>>>>>> 50fe548 (feat(FTDAS): Create POST /todos api to create task)
 import { TasksService } from './tasks.service';
 import { Task } from 'src/common/entities/task.entity';
+
 import { CreateTaskDto } from './tasks.dto';
 >>>>>>> dc64799 (feat(FTDAS): Create POST /todos api to create task)
 

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 import {
   Body,
   Controller,
@@ -11,6 +12,12 @@ import {
 import { TasksService } from './tasks.service';
 import { Task } from 'src/common/entities/task.entity';
 import { CreateTaskDto, UpdateTaskDto } from './tasks.dto';
+=======
+import { Controller, Get } from '@nestjs/common';
+
+import { TasksService } from './tasks.service';
+import { Task } from 'src/common/entities/task.entity';
+>>>>>>> 66b362b (feat(FTDAS): Get api for all todos)
 
 @Controller('todos')
 export class TasksController {
@@ -20,6 +27,7 @@ export class TasksController {
   async findAll(): Promise<Task[]> {
     return this.tasksService.findAll();
   }
+<<<<<<< HEAD
 
   @Post()
   async createOne(@Body() createTaskDto: CreateTaskDto): Promise<Task> {
@@ -63,4 +71,6 @@ export class TasksController {
   async removeCompleted(): Promise<void> {
     await this.tasksService.removeCompleted();
   }
+=======
+>>>>>>> 66b362b (feat(FTDAS): Get api for all todos)
 }

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -2,6 +2,9 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 31ac275 (feat(FTDAS): Add Delete /todos/:id api and delete functionality)
 import {
   Body,
   Controller,
@@ -11,6 +14,7 @@ import {
   Post,
   Put,
 } from '@nestjs/common';
+<<<<<<< HEAD
 
 import { TasksService } from './tasks.service';
 import { Task } from 'src/common/entities/task.entity';
@@ -40,6 +44,8 @@ import { CreateTaskDto } from './tasks.dto';
 >>>>>>> dc64799 (feat(FTDAS): Create POST /todos api to create task)
 =======
 import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common';
+=======
+>>>>>>> 31ac275 (feat(FTDAS): Add Delete /todos/:id api and delete functionality)
 
 import { TasksService } from './tasks.service';
 import { Task } from 'src/common/entities/task.entity';
@@ -118,5 +124,13 @@ export class TasksController {
   ): Promise<Task> {
     return this.tasksService.updateTask(+id, updateTaskDto);
   }
+<<<<<<< HEAD
 >>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
+=======
+
+  @Delete(':id')
+  async deleteTask(@Param('id') id: string) {
+    return await this.tasksService.deleteTask(+id);
+  }
+>>>>>>> 31ac275 (feat(FTDAS): Add Delete /todos/:id api and delete functionality)
 }

--- a/src/tasks/tasks.module.ts
+++ b/src/tasks/tasks.module.ts
@@ -4,11 +4,19 @@ import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { TasksController } from './tasks.controller';
 import { TasksService } from './tasks.service';
 import { Task } from 'src/common/entities/task.entity';
+<<<<<<< HEAD
 import { TasksRepository } from './tasks.repository';
+=======
+import { TaskRepository } from './tasks.repository';
+>>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
 
 @Module({
   imports: [MikroOrmModule.forFeature([Task])],
   controllers: [TasksController],
+<<<<<<< HEAD
   providers: [TasksService, TasksRepository],
+=======
+  providers: [TasksService, TaskRepository],
+>>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
 })
 export class TasksModule {}

--- a/src/tasks/tasks.module.ts
+++ b/src/tasks/tasks.module.ts
@@ -5,18 +5,26 @@ import { TasksController } from './tasks.controller';
 import { TasksService } from './tasks.service';
 import { Task } from 'src/common/entities/task.entity';
 <<<<<<< HEAD
+<<<<<<< HEAD
 import { TasksRepository } from './tasks.repository';
 =======
 import { TaskRepository } from './tasks.repository';
 >>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
+=======
+import { TasksRepository } from './tasks.repository';
+>>>>>>> 86bb982 (chore(FTDA): Enbale CORS for localhost:3000)
 
 @Module({
   imports: [MikroOrmModule.forFeature([Task])],
   controllers: [TasksController],
 <<<<<<< HEAD
+<<<<<<< HEAD
   providers: [TasksService, TasksRepository],
 =======
   providers: [TasksService, TaskRepository],
 >>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
+=======
+  providers: [TasksService, TasksRepository],
+>>>>>>> 86bb982 (chore(FTDA): Enbale CORS for localhost:3000)
 })
 export class TasksModule {}

--- a/src/tasks/tasks.module.ts
+++ b/src/tasks/tasks.module.ts
@@ -4,27 +4,11 @@ import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { TasksController } from './tasks.controller';
 import { TasksService } from './tasks.service';
 import { Task } from 'src/common/entities/task.entity';
-<<<<<<< HEAD
-<<<<<<< HEAD
 import { TasksRepository } from './tasks.repository';
-=======
-import { TaskRepository } from './tasks.repository';
->>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
-=======
-import { TasksRepository } from './tasks.repository';
->>>>>>> 86bb982 (chore(FTDA): Enbale CORS for localhost:3000)
 
 @Module({
   imports: [MikroOrmModule.forFeature([Task])],
   controllers: [TasksController],
-<<<<<<< HEAD
-<<<<<<< HEAD
   providers: [TasksService, TasksRepository],
-=======
-  providers: [TasksService, TaskRepository],
->>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
-=======
-  providers: [TasksService, TasksRepository],
->>>>>>> 86bb982 (chore(FTDA): Enbale CORS for localhost:3000)
 })
 export class TasksModule {}

--- a/src/tasks/tasks.repository.ts
+++ b/src/tasks/tasks.repository.ts
@@ -104,15 +104,26 @@ export class TasksRepository extends EntityRepository<Task> {
 >>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
 =======
 import { Injectable } from '@nestjs/common';
+
 import { Task } from 'src/common/entities/task.entity';
-import { UpdateTaskDto } from './tasks.dto';
+import { CreateTaskDto, UpdateTaskDto } from './tasks.dto';
 
 @Injectable()
-export class TaskRepository extends EntityRepository<Task> {
+export class TasksRepository extends EntityRepository<Task> {
   constructor(em: EntityManager) {
     super(em, Task);
   }
+  async getAllTasks(): Promise<Task[]> {
+    return this.findAll();
+  }
 
+  async createOne(createTaskDto: CreateTaskDto): Promise<Task> {
+    const task = this.create(createTaskDto);
+    await this.em.persistAndFlush(task);
+    return task;
+  }
+
+<<<<<<< HEAD
 >>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
   async updateTask(id: number, updateTaskDto: UpdateTaskDto): Promise<Task> {
     const task = await this.findOne(id);
@@ -143,10 +154,18 @@ export class TaskRepository extends EntityRepository<Task> {
     return task;
   }
 >>>>>>> 3e90812 (feat(FTDAS): Add Delete /todos/completed to delete completed tasks)
+=======
+  async updateOne(task: Task, updateTaskDto: UpdateTaskDto): Promise<Task> {
+    this.assign(task, updateTaskDto);
+    await this.em.persistAndFlush(task);
+    return task;
+  }
+>>>>>>> 3e90812 (feat(FTDAS): Add Delete /todos/completed to delete completed tasks)
 
   async deleteOne(task: Task) {
     await this.em.removeAndFlush(task);
   }
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 >>>>>>> 3c04e04 (feat(FTDAS): Add Get /todos/:id API to fetch one task)
@@ -172,10 +191,13 @@ export class TaskRepository extends EntityRepository<Task> {
 =======
 =======
 >>>>>>> 3e90812 (feat(FTDAS): Add Delete /todos/completed to delete completed tasks)
+=======
+>>>>>>> 3e90812 (feat(FTDAS): Add Delete /todos/completed to delete completed tasks)
 
   async removeCompleted(tasks: Task[]): Promise<void> {
     await this.em.removeAndFlush(tasks);
   }
+<<<<<<< HEAD
 <<<<<<< HEAD
 >>>>>>> 3e90812 (feat(FTDAS): Add Delete /todos/completed to delete completed tasks)
 =======
@@ -188,4 +210,6 @@ export class TaskRepository extends EntityRepository<Task> {
 >>>>>>> 1352e66 (feat(FTDAS): Get api for all todos)
 =======
 >>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
+=======
+>>>>>>> 3e90812 (feat(FTDAS): Add Delete /todos/completed to delete completed tasks)
 }

--- a/src/tasks/tasks.repository.ts
+++ b/src/tasks/tasks.repository.ts
@@ -3,6 +3,7 @@ import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 import { Injectable } from '@nestjs/common';
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -138,6 +139,8 @@ export class TasksRepository extends EntityRepository<Task> {
 =======
 =======
 >>>>>>> 1352e66 (feat(FTDAS): Get api for all todos)
+=======
+>>>>>>> 1352e66 (feat(FTDAS): Get api for all todos)
 import { Task } from 'src/common/entities/task.entity';
 
 export class TaskRepository extends EntityRepository<Task> {
@@ -147,6 +150,7 @@ export class TaskRepository extends EntityRepository<Task> {
   async getAllTasks(): Promise<Task[]> {
     return await this.findAll();
   }
+<<<<<<< HEAD
 <<<<<<< HEAD
 >>>>>>> 1352e66 (feat(FTDAS): Get api for all todos)
 =======
@@ -166,4 +170,6 @@ export class TaskRepository extends EntityRepository<Task> {
 >>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
 =======
 >>>>>>> 3e90812 (feat(FTDAS): Add Delete /todos/completed to delete completed tasks)
+=======
+>>>>>>> 1352e66 (feat(FTDAS): Get api for all todos)
 }

--- a/src/tasks/tasks.repository.ts
+++ b/src/tasks/tasks.repository.ts
@@ -199,6 +199,7 @@ export class TaskRepository extends EntityRepository<Task> {
   }
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 >>>>>>> 3e90812 (feat(FTDAS): Add Delete /todos/completed to delete completed tasks)
 =======
 >>>>>>> 1352e66 (feat(FTDAS): Get api for all todos)
@@ -212,4 +213,12 @@ export class TaskRepository extends EntityRepository<Task> {
 >>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
 =======
 >>>>>>> 3e90812 (feat(FTDAS): Add Delete /todos/completed to delete completed tasks)
+=======
+
+  async syncTasks(tasks: Task[]): Promise<void> {
+    await this.nativeDelete({});
+    const taskEntities = tasks.map((taskData) => this.create(taskData));
+    await this.em.persistAndFlush(taskEntities);
+  }
+>>>>>>> c979ab8 (feat(FTDA): Add Put api to replace tasks from database)
 }

--- a/src/tasks/tasks.repository.ts
+++ b/src/tasks/tasks.repository.ts
@@ -4,6 +4,7 @@ import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 import { Injectable } from '@nestjs/common';
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -101,6 +102,18 @@ export class TasksRepository extends EntityRepository<Task> {
 
 <<<<<<< HEAD
 >>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
+=======
+import { Injectable } from '@nestjs/common';
+import { Task } from 'src/common/entities/task.entity';
+import { UpdateTaskDto } from './tasks.dto';
+
+@Injectable()
+export class TaskRepository extends EntityRepository<Task> {
+  constructor(em: EntityManager) {
+    super(em, Task);
+  }
+
+>>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
   async updateTask(id: number, updateTaskDto: UpdateTaskDto): Promise<Task> {
     const task = await this.findOne(id);
     if (task) {
@@ -109,6 +122,7 @@ export class TasksRepository extends EntityRepository<Task> {
     }
     return task;
   }
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 >>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
@@ -172,4 +186,6 @@ export class TaskRepository extends EntityRepository<Task> {
 >>>>>>> 3e90812 (feat(FTDAS): Add Delete /todos/completed to delete completed tasks)
 =======
 >>>>>>> 1352e66 (feat(FTDAS): Get api for all todos)
+=======
+>>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
 }

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -13,6 +13,7 @@ import { Injectable } from '@nestjs/common';
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 import { Task } from 'src/common/entities/task.entity';
 import { CreateTaskDto, UpdateTaskDto } from './tasks.dto';
@@ -50,6 +51,8 @@ import { Task } from 'src/common/entities/task.entity';
 =======
 =======
 import { EntityManager } from '@mikro-orm/postgresql';
+=======
+>>>>>>> 3e90812 (feat(FTDAS): Add Delete /todos/completed to delete completed tasks)
 
 >>>>>>> c30c7e8 (feat(FTDAS): Add Get /todos/:id API to fetch one task)
 import { Task } from 'src/common/entities/task.entity';
@@ -88,6 +91,7 @@ import { CreateTaskDto } from './tasks.dto';
 =======
 import { Task } from 'src/common/entities/task.entity';
 import { CreateTaskDto, UpdateTaskDto } from './tasks.dto';
+<<<<<<< HEAD
 <<<<<<< HEAD
 import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
 import { TaskRepository } from './tasks.repository';
@@ -299,20 +303,40 @@ export class TasksService {
     await this.em.persistAndFlush(task);
     return task;
 >>>>>>> dc64799 (feat(FTDAS): Create POST /todos api to create task)
+=======
+import { TasksRepository } from './tasks.repository';
+
+@Injectable()
+export class TasksService {
+  constructor(private readonly tasksRepository: TasksRepository) {}
+
+  async findAll(): Promise<Task[]> {
+    return await this.tasksRepository.findAll();
+  }
+
+  async createTask(createTaskDto: CreateTaskDto): Promise<Task> {
+    return await this.tasksRepository.createOne(createTaskDto);
+>>>>>>> 3e90812 (feat(FTDAS): Add Delete /todos/completed to delete completed tasks)
   }
 
   async updateTask(id: number, updateTaskDto: UpdateTaskDto): Promise<Task> {
-    return await this.taskRepository.updateTask(id, updateTaskDto);
+    const task = await this.tasksRepository.findOneOrFail(id);
+    return await this.tasksRepository.updateOne(task, updateTaskDto);
   }
 
   async deleteTask(id: number) {
-    const task = await this.taskRepository.findOne(id);
-    if (task) {
-      await this.em.removeAndFlush(task);
-    }
+    const task = await this.tasksRepository.findOne(id);
+    return await this.tasksRepository.deleteOne(task);
   }
 
-  async findOneTask(id: number): Promise<Task> {
-    return await this.taskRepository.findOneOrFail(id);
+  async findOne(id: number): Promise<Task> {
+    return await this.tasksRepository.findOneOrFail(id);
+  }
+
+  async removeCompleted(): Promise<void> {
+    const completedTasks = await this.tasksRepository.find({
+      status: 'completed',
+    });
+    await this.tasksRepository.removeCompleted(completedTasks);
   }
 }

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -307,4 +307,11 @@ export class TasksService {
       await this.em.removeAndFlush(task);
     }
   }
+
+  async deleteTask(id: number) {
+    const task = await this.taskRepository.findOne(id);
+    if (task) {
+      await this.em.removeAndFlush(task);
+    }
+  }
 }

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -12,6 +12,7 @@ import { Injectable } from '@nestjs/common';
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 import { Task } from 'src/common/entities/task.entity';
 import { CreateTaskDto, UpdateTaskDto } from './tasks.dto';
@@ -102,9 +103,12 @@ import { Task } from 'src/common/entities/task.entity';
 import { CreateTaskDto } from './tasks.dto';
 >>>>>>> dc64799 (feat(FTDAS): Create POST /todos api to create task)
 =======
+=======
+import { EntityManager } from '@mikro-orm/postgresql';
+
+>>>>>>> c30c7e8 (feat(FTDAS): Add Get /todos/:id API to fetch one task)
 import { Task } from 'src/common/entities/task.entity';
 import { CreateTaskDto, UpdateTaskDto } from './tasks.dto';
-import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
 import { TaskRepository } from './tasks.repository';
 >>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
 
@@ -308,10 +312,7 @@ export class TasksService {
     }
   }
 
-  async deleteTask(id: number) {
-    const task = await this.taskRepository.findOne(id);
-    if (task) {
-      await this.em.removeAndFlush(task);
-    }
+  async findOneTask(id: number): Promise<Task> {
+    return await this.taskRepository.findOneOrFail(id);
   }
 }

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -105,7 +105,6 @@ import { CreateTaskDto } from './tasks.dto';
 import { Task } from 'src/common/entities/task.entity';
 import { CreateTaskDto, UpdateTaskDto } from './tasks.dto';
 import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
-import { InjectRepository } from '@mikro-orm/nestjs';
 import { TaskRepository } from './tasks.repository';
 >>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
 
@@ -300,5 +299,12 @@ export class TasksService {
 
   async updateTask(id: number, updateTaskDto: UpdateTaskDto): Promise<Task> {
     return await this.taskRepository.updateTask(id, updateTaskDto);
+  }
+
+  async deleteTask(id: number) {
+    const task = await this.taskRepository.findOne(id);
+    if (task) {
+      await this.em.removeAndFlush(task);
+    }
   }
 }

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -11,6 +11,7 @@ import { Injectable } from '@nestjs/common';
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 import { Task } from 'src/common/entities/task.entity';
 import { CreateTaskDto, UpdateTaskDto } from './tasks.dto';
@@ -100,10 +101,18 @@ import { Task } from 'src/common/entities/task.entity';
 =======
 import { CreateTaskDto } from './tasks.dto';
 >>>>>>> dc64799 (feat(FTDAS): Create POST /todos api to create task)
+=======
+import { Task } from 'src/common/entities/task.entity';
+import { CreateTaskDto, UpdateTaskDto } from './tasks.dto';
+import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { TaskRepository } from './tasks.repository';
+>>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
 
 @Injectable()
 export class TasksService {
   constructor(
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -268,6 +277,9 @@ export class TasksService {
 =======
     @InjectRepository(Task)
     private readonly taskRepository: EntityRepository<Task>,
+=======
+    private readonly taskRepository: TaskRepository,
+>>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
     private readonly em: EntityManager,
   ) {}
 
@@ -284,5 +296,9 @@ export class TasksService {
     await this.em.persistAndFlush(task);
     return task;
 >>>>>>> dc64799 (feat(FTDAS): Create POST /todos api to create task)
+  }
+
+  async updateTask(id: number, updateTaskDto: UpdateTaskDto): Promise<Task> {
+    return await this.taskRepository.updateTask(id, updateTaskDto);
   }
 }

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -10,6 +10,7 @@ import { Injectable } from '@nestjs/common';
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 import { Task } from 'src/common/entities/task.entity';
 import { CreateTaskDto, UpdateTaskDto } from './tasks.dto';
@@ -89,10 +90,17 @@ import { CreateTaskDto, UpdateTaskDto } from './tasks.dto';
 import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
 import { TaskRepository } from './tasks.repository';
 >>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
+=======
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { EntityRepository } from '@mikro-orm/postgresql';
+
+import { Task } from 'src/common/entities/task.entity';
+>>>>>>> 66b362b (feat(FTDAS): Get api for all todos)
 
 @Injectable()
 export class TasksService {
   constructor(
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -253,5 +261,12 @@ export class TasksService {
       status: 'completed',
     });
     await this.tasksRepository.removeCompleted(completedTasks);
+=======
+    @InjectRepository(Task)
+    private readonly taskRepository: EntityRepository<Task>,
+  ) {}
+  async findAll(): Promise<Task[]> {
+    return this.taskRepository.findAll();
+>>>>>>> 66b362b (feat(FTDAS): Get api for all todos)
   }
 }

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -339,4 +339,8 @@ export class TasksService {
     });
     await this.tasksRepository.removeCompleted(completedTasks);
   }
+
+  async syncTasks(tasks: Task[]): Promise<void> {
+    await this.tasksRepository.syncTasks(tasks);
+  }
 }

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -92,10 +92,14 @@ import { TaskRepository } from './tasks.repository';
 >>>>>>> 57d0b96 (feat(FTDAS): Create PUT /todos/:id to update task)
 =======
 import { InjectRepository } from '@mikro-orm/nestjs';
-import { EntityRepository } from '@mikro-orm/postgresql';
+import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
 
 import { Task } from 'src/common/entities/task.entity';
+<<<<<<< HEAD
 >>>>>>> 66b362b (feat(FTDAS): Get api for all todos)
+=======
+import { CreateTaskDto } from './tasks.dto';
+>>>>>>> dc64799 (feat(FTDAS): Create POST /todos api to create task)
 
 @Injectable()
 export class TasksService {
@@ -264,9 +268,21 @@ export class TasksService {
 =======
     @InjectRepository(Task)
     private readonly taskRepository: EntityRepository<Task>,
+    private readonly em: EntityManager,
   ) {}
+
   async findAll(): Promise<Task[]> {
+<<<<<<< HEAD
     return this.taskRepository.findAll();
 >>>>>>> 66b362b (feat(FTDAS): Get api for all todos)
+=======
+    return await this.taskRepository.findAll();
+  }
+
+  async createTask(createTaskDto: CreateTaskDto): Promise<Task> {
+    const task = this.taskRepository.create(createTaskDto);
+    await this.em.persistAndFlush(task);
+    return task;
+>>>>>>> dc64799 (feat(FTDAS): Create POST /todos api to create task)
   }
 }

--- a/temp/Task.js.json
+++ b/temp/Task.js.json
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 {
   "data": {
     "_id": 0,
@@ -86,3 +87,6 @@
   "hash": "88586d7213c879d4e689b4887555a5bf",
   "version": "6.3.2"
 }
+=======
+{"data":{"_id":0,"properties":{"id":{"name":"id","kind":"scalar","primary":true,"type":"number","array":false,"runtimeType":"number"},"title":{"name":"title","kind":"scalar","getter":false,"setter":false,"fieldNames":["title"],"type":"string","array":false,"runtimeType":"string"},"description":{"name":"description","kind":"scalar","nullable":true,"getter":false,"setter":false,"fieldNames":["description"],"type":"string","array":false,"runtimeType":"string","optional":true},"dueDate":{"name":"dueDate","kind":"scalar","nullable":true,"getter":false,"setter":false,"fieldNames":["due_date"],"type":"Date","array":false,"runtimeType":"Date","optional":true},"priority":{"name":"priority","kind":"scalar","getter":false,"setter":false,"fieldNames":["priority"],"type":"string","array":false,"runtimeType":"string"},"status":{"name":"status","kind":"scalar","getter":false,"setter":false,"fieldNames":["status"],"type":"string","array":false,"runtimeType":"string"}},"primaryKeys":["id"],"filters":{},"hooks":{},"indexes":[],"uniques":[],"className":"Task","path":"./dist/src/common/entities/task.entity.js","collection":"task","name":"Task","abstract":false,"internal":true,"constructorParams":[],"toJsonParams":[],"useCache":true,"compositePK":false,"simplePK":true},"origin":"./dist/src/common/entities/task.entity.js","hash":"88586d7213c879d4e689b4887555a5bf","version":"6.3.2"}
+>>>>>>> 86bb982 (chore(FTDA): Enbale CORS for localhost:3000)


### PR DESCRIPTION
### Description of Change
- Add a PUT /todos api to replace tasks from DB at controller
- Added functionality at repository layer
- Firstly removed all the existing tasks
- Then inserting the given tasks at DB
### Associated Ticket Link:
- https://trello.com/c/6uA1Ap9n
### Related Pull Request: N/A
### Screenshots / Screen Recordings: N/A

